### PR TITLE
Update package tooltip

### DIFF
--- a/_includes/package.html
+++ b/_includes/package.html
@@ -18,7 +18,7 @@
    <a class="pkg-link" title="repository" href="{{pkg.repository}}"><i class="fa fa-code"></i></a>
   {% endif %}
 
-  <a class="pkg-link action" title="repository" href="#pkg-{{pkg.id}}"><i class="fa fa-hashtag"></i></a>
+  <a class="pkg-link action" title="permalink" href="#pkg-{{pkg.id}}"><i class="fa fa-hashtag"></i></a>
 
 
 


### PR DESCRIPTION
Currently the permalink's title is `repository`. This corrects this issue.
