### PR TITLE
Add Pleingres

### DIFF
--- a/topics/database.md
+++ b/topics/database.md
@@ -10,6 +10,7 @@ intro: Proper Database support is crucial for modern web development. This page 
 drivers:
  - mysql
  - postgres
+ - pleingres
  - redis
  - rusqlite
  - leveldb


### PR DESCRIPTION
Pleingres is a non-blocking native driver to Postgresql which only allocates memory when starting your server up.