### PR TITLE
Reformat 'What should I replace it with?' content

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,10 +16,64 @@ layout: main
 
 ### What should I replace it with?
 
-The frameworks of choice of the community are <a href="/topics/frameworks/#pkg-iron">iron</a>, <a href="/topics/frameworks/#pkg-conduit">conduit</a> and <a href="/topics/frameworks/#pkg-nickel">nickel</a>, best run with a <a href="/topics/database/#pkg-postgres">postgres</a> or <a href="/topics/database/#pkg-mysql">mysql</a> backend accompanied by <a href="/topics/database/#pkg-redis">redis</a> – all these drivers seem to be fairly mature. If you want to wrap that into an ORM <a href="/topics/database/#pkg-rustorm">rustorm</a> and <a href="/topics/database/#pkg-diesel">diesel</a> are at your disposal – both are still fairly young though. <a href="/topics/frameworks/#pkg-rocket">Rocket</a> is a newer framework focused on ease-of-use, expressability and speed
-.
+The web frameworks of choice in the community are:
 
-If you need to (or want to) go lower in the stack, those frameworks all use the fairly stable and mature <a href="/topics/stack/#pkg-hyper">hyper http stack</a>, if you want it slimmer <a href="/topics/stack/#pkg-tiny_http">tiny_http</a> might be an option and for the async-fans <a href="/topics/stack/#pkg-rotor-http">rotor</a> has you covered. If you need HTTP2, you have to turn to <a href="/topics/stack/#pkg-solicit">solicit</a> as none of the other stacks supports it just yet.
+<ul>
+  <li>
+    <a href="/topics/frameworks/#pkg-conduit">Conduit</a>
+  </li>
+  <li>
+    <a href="/topics/frameworks/#pkg-iron">Iron</a>
+  </li>
+  <li>
+    <a href="/topics/frameworks/#pkg-nickel">Nickel</a>
+  </li>
+  <li>
+    <a href="/topics/frameworks/#pkg-rocket">Rocket</a>
+  </li>
+</ul>
+
+For data storage there are mature drivers for:
+
+<ul>
+  <li>
+    <a href="/topics/database/#pkg-mysql">Mysql</a>
+  </li>
+  <li>
+    <a href="/topics/database/#pkg-postgres">Postgres</a> 
+  </li>
+  <li>
+    <a href="/topics/database/#pkg-redis">Redis</a>
+  </li>
+</ul>
+
+If you'd like to use an ORM there is:
+
+<ul>
+  <li>
+    <a href="/topics/database/#pkg-diesel">Diesel (Postgres / Mysql / Sqlite)</a>
+  </li>
+  <li>
+    <a href="/topics/database/#pkg-rustorm">Rustorm (Postgres / Sqlite)</a>
+  </li>
+</ul>
+
+If you need to (or want to) go lower in the stack:
+
+<ul>
+  <li>
+    <a href="/topics/stack/#pkg-hyper">Hyper</a>
+  </li>
+  <li>
+    <a href="/topics/stack/#pkg-rotor-http">Rotor</a>
+  </li>
+  <li>
+    <a href="/topics/stack/#pkg-solicit">Solicit</a>
+  </li>
+  <li>
+    <a href="/topics/stack/#pkg-tiny_http">tiny_http</a> 
+  </li>
+</ul>
 
 ### Getting started
 


### PR DESCRIPTION
I was looking into adding Gotham to the arewewebyet website and whilst reading the 'What should I replace it with?' content I felt like it was becoming a little cluttered.

I've played with a few options and what seemed to come out the cleanest to me was a simple list of alphabetized links as proposed in this PR.

If this is of interest I am happy to make any tweaks you may consider of benefit, I'll also send the related Gotham PR shortly for consideration.