### PR TITLE
Remove 'i18n' crate

### DIFF
--- a/topics/i18n.md
+++ b/topics/i18n.md
@@ -4,7 +4,7 @@ title: "Internationalisation"
 
 level: 5
 
-intro: Internationalisation is still very immature and unstable, with most libraries being only weeks old and not used in production yet. Further more, other than the usual gettext approach, the rust ecosystem doesn't offer much yet. ICU is completely non-existant.
+intro: Internationalisation is still very immature and unstable, with most libraries being only weeks old and not used in production yet. Furthermore, other than the usual gettext approach, the Rust ecosystem doesn't offer much yet. ICU is completely non-existent.
 
 
 packages:

--- a/topics/i18n.md
+++ b/topics/i18n.md
@@ -10,7 +10,6 @@ intro: Internationalisation is still very immature and unstable, with most libra
 packages:
   - gettext
   - gettext-rs
-  - i18n
   - l20n
   - libphonenumber-sys
 


### PR DESCRIPTION
Fix for #86 - the i18n crate has been yanked from crates.io.