### PR TITLE
Remove "hyper-tokio" from "upcoming" section in "Lower Web-Stack"

### DIFF
--- a/topics/stack.md
+++ b/topics/stack.md
@@ -30,9 +30,6 @@ news_tag: stack
 
 
 upcoming:
- - name: hyper-tokio
-   url: https://github.com/hyperium/hyper/issues/934
-   desc: a tokio/futures based hyper
  - name: fractalide
    url: https://github.com/fractalide/fractalide
    desc: simple rust microservices


### PR DESCRIPTION
fixes #89.