### PR TITLE
Remove references to clippy-service

### DIFF
--- a/index.md
+++ b/index.md
@@ -80,7 +80,7 @@ If you need to (or want to) go lower in the stack:
 
 ### Getting started
 
-After you've set up your Rust and worked yourself [through "The Book"](https://doc.rust-lang.org/book/), we highly recommend taking a look at [fully annotated source code](https://clippy.bashy.io/docs/) of the [clippy-service](https://clippy.bashy.io), an iron-based microservice, which shows how to use many common features like redis database connections or JSON parsing. Otherwise you might want to check any of these blog posts (ordered latest published first):
+After you've set up your Rust and worked yourself [through "The Book"](https://doc.rust-lang.org/book/), you might want to check any of these blog posts (ordered latest published first):
 
 - [Using Stainless with Rocket](http://neikos.me/Using_Stainless_with_Rocket.html)
 - [REST in Rust](https://gsquire.github.io/static/post/rest-in-rust/)


### PR DESCRIPTION
This site seems to be dead, and besides, we shouldn't be pointing at Iron examples any more.