### PR TITLE
Deployment - Docker Information Update

### DIFF
--- a/topics/deploy.md
+++ b/topics/deploy.md
@@ -12,9 +12,9 @@ intro: How are on quick and easy deploying of our applications into existing ser
 
 You didn't really expect Heroku to support rust natively, did you? But if you are looking at this subject, you probably are familiar with running heroku with an inofficial [buildpack](https://devcenter.heroku.com/articles/buildpacks). In that case, you are in a lot of luck, because [EMK](https://github.com/emk) provides that for you already: [github.com/emk/heroku-buildpack-rust](https://github.com/emk/heroku-buildpack-rust)
 
-<h2>Docker {% include level.html level=3 %}</h2>
+<h2>Docker {% include level.html level=2 %}</h2>
 
-There are a few docker images for rust, but only [Scorpils](https://github.com/Scorpil) [Dockerfiles](https://github.com/Scorpil/docker-rust) support the latest version as well as the unstable nightly builds. There is [even some discussion](https://users.rust-lang.org/t/creating-official-docker-image-for-rust/4165) on moving the repo to the official Rust-Github-Organisation.
+There are [official docker images](https://github.com/rust-lang-nursery/docker-rust) for rust ([`rust`](https://hub.docker.com/_/rust/)). Additionally, there are nightly images available ([`rustlang/rust`](https://hub.docker.com/r/rustlang/rust/)) if your application requires it. If you use docker's [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/), you can build your application binary and then copy it into a container. This allows you to avoid deploying the entire compilation toolchain with your web application.
 
 <h2>Unikernels {% include level.html level=4 %}</h2>
 


### PR DESCRIPTION
I tried to update the docker information to match the current state of the rust + docker. I incremented the level to tier two. My reasoning for this change is because there is official support, but it isn't web-specific and only lets you specify the latest nightly instead of a pinned version.

I'm happy to make whatever changes are desired to the PR.

Resolves #125 