### PR TITLE
Removed Conduit and Solicit.

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,9 +23,6 @@ The web frameworks of choice in the community are:
     <a href="/topics/frameworks/#pkg-actix-web">Actix</a>
   </li>
   <li>
-    <a href="/topics/frameworks/#pkg-conduit">Conduit</a>
-  </li>
-  <li>
     <a href="/topics/frameworks/#pkg-gotham">Gotham</a>
   </li>
   <li>
@@ -72,9 +69,6 @@ If you need to (or want to) go lower in the stack:
   </li>
   <li>
     <a href="/topics/stack/#pkg-hyper">Hyper</a>
-  </li>
-  <li>
-    <a href="/topics/stack/#pkg-solicit">Solicit</a>
   </li>
   <li>
     <a href="/topics/stack/#pkg-tiny_http">tiny_http</a>


### PR DESCRIPTION
Both these crates seem to be unmaintained for quite a long time now: 

* [Conduit](https://crates.io/crates/conduit) was last released on Jan 2017.
* [Solicit](https://crates.io/crates/solicit) was last released on Sep 2015.

I did not remove them from the topics, since the contribution guidelines for adding crates don't mention that the library must be maintained and active.  However, I think it should say something along those lines, so I opened #127.

Fixes #124.