### PR TITLE
removed *upcoming* section from cms topic

### DIFF
--- a/topics/cms.md
+++ b/topics/cms.md
@@ -8,13 +8,5 @@ level: 4
 packages:
  - cobalt-bin
 
-upcoming:
- - name: lightning-rs
-   url: https://github.com/chriskrycho/lightning-rs
-   desc: Yet another static site generator
- - name: iron-cms
-   url: https://github.com/mrLSD/iron-cms
-   desc: a CMS for iron
-
 news_tag: cms
 ---


### PR DESCRIPTION
#164 

There are two repos mentioned in this section: **lightning-rs** and **iron-cms**
- **lightning-rs** status `does not work`, not yet published
  https://github.com/chriskrycho/lightning-rs
- **iron-cms** status `Active development`, last commit 6 Mar 2017
  https://github.com/mrLSD/iron-cms