### PR TITLE
fixed description for web-api topic

### DIFF
--- a/topics/web-apis.md
+++ b/topics/web-apis.md
@@ -42,5 +42,3 @@ news_tag: apis
 ---
 
 Connecting to the outside world is important, too many modern web applications are useless without an external party they connect to and interact with. This is an incomplete list of API(-wrapper)-Implementations in Rust:
-
-rust-sqlite


### PR DESCRIPTION
removed `rust-sqlite` line from web-api topic description, looks like a typo