### PR TITLE
Removed rust-crypto from description in the crypto topic

### DIFF
--- a/topics/crypto.md
+++ b/topics/crypto.md
@@ -51,8 +51,6 @@ news_tag: crypto
 
 <h2>Suites  {% include level.html level=2 %}</h2>
 
-<p><em>While openssl is the most popular suite, rust-crypto remains the only memory-safe option.</em></p>
-
 {% include packages.html packages=page.suites %}
 
 


### PR DESCRIPTION
Adresses https://github.com/rustasync/arewewebyet/pull/169#commitcomment-33418470