### PR TITLE
Cleared recommended frameworks, removed outdated comment about iron

### DIFF
--- a/_data/comments/iron.yaml
+++ b/_data/comments/iron.yaml
@@ -1,6 +1,0 @@
-- author: flosse
-  date: 2015/08/16
-  version: 0.1.20
-  type: info
-  source_link: "https://github.com/flosse/rust-web-framework-comparison#middleware--plugins"
-  text: "Most basic Features complete: Static File Serving ✓, Mounting ✓, Logging ✓, JSON-Body ✓, Sessions ✓, Cookies ✓ , HTTPS ✓ . Database Support/ORM: ✗ ."

--- a/index.md
+++ b/index.md
@@ -23,10 +23,16 @@ The web frameworks of choice in the community are:
     <a href="/topics/frameworks/#pkg-actix-web">Actix</a>
   </li>
   <li>
+    <a href="/topics/frameworks/#pkg-gotham">Gotham</a>
+  </li>
+  <li>
     <a href="/topics/frameworks/#pkg-rocket">Rocket</a>
   </li>
   <li>
     <a href="/topics/frameworks/#pkg-tower-web">Tower Web</a>
+  </li>
+  <li>
+    <a href="/topics/frameworks/#pkg-warp">Warp</a>
   </li>
 </ul>
 

--- a/index.md
+++ b/index.md
@@ -23,22 +23,10 @@ The web frameworks of choice in the community are:
     <a href="/topics/frameworks/#pkg-actix-web">Actix</a>
   </li>
   <li>
-    <a href="/topics/frameworks/#pkg-gotham">Gotham</a>
-  </li>
-  <li>
-    <a href="/topics/frameworks/#pkg-iron">Iron</a>
-  </li>
-  <li>
-    <a href="/topics/frameworks/#pkg-nickel">Nickel</a>
-  </li>
-  <li>
     <a href="/topics/frameworks/#pkg-rocket">Rocket</a>
   </li>
   <li>
     <a href="/topics/frameworks/#pkg-tower-web">Tower Web</a>
-  </li>
-  <li>
-    <a href="/topics/frameworks/#pkg-warp">Warp</a>
   </li>
 </ul>
 


### PR DESCRIPTION
This pr updates recommended frameworks on the front page to:
- actix-web
- gotham
- rocket
- tower-web
- warp

If you think I missed something, feel free to comment here, I'd be happy to update changes. There's still a [frameworks](https://www.arewewebyet.org/topics/frameworks/) topic, which contains most of the existing frameworks.
I also deleted outdated comment about the `iron` from `frameworks` topic to reduce the noise.