### PR TITLE
Less margin on title

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -118,7 +118,7 @@ h1 {
 }
 
 #main h1 + p {
-	margin: 0 0 1em;
+	margin: 0 0 0.5em;
 	color: #000;
 	font-size: 5rem;
 }


### PR DESCRIPTION
There is curently a bit too much margin between "Yes! And its freaking fast!" and "Can I replace my Rails/Django/Flask already?". I lowered it from 1em to 0.5em.