### PR TITLE
Fix spelling

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: main
 
 # Are we _web_ yet?
 
-**Yes! And its freaking fast!**
+**Yes! And it's freaking fast!**
 
 ## Can I replace my Rails/Django/Flask already?
 


### PR DESCRIPTION
I think there is an apostrophe missing in the new heading: its -> it’s