### PR TITLE
Add the `tracing` crate to the logging category

### DIFF
--- a/content/topics/logging.md
+++ b/content/topics/logging.md
@@ -17,7 +17,8 @@ packages = [
   "syslog",
   "flexi_logger",
   "sentry",
-  "slog"
+  "slog",
+  "tracing"
 ]
 
 newstag = "logging"


### PR DESCRIPTION
I think the [`tracing`](https://crates.io/crates/tracing) crate fits in the `logging` category.