### PR TITLE
Fix typo on home page

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -67,7 +67,7 @@
   
   <p>
     Rust does not have a dominant framework at the level of Django or Rails. Most Rust frameworks are smaller and modular, similar to Flask or Sinatra. 
-    Rust does has a diverse package ecosystem, but you generally have to wire everything up yourself. Expect to put in a little bit of extra set up work 
+    Rust does have a diverse package ecosystem, but you generally have to wire everything up yourself. Expect to put in a little bit of extra set up work 
     to get started. If you are expecting everything bundled up for you, then Rust might not be for you just yet.
   </p>
 


### PR DESCRIPTION
I assumed the use of `has` was just a typo here