### PR TITLE
Fix a typo in Internationalization word

### DIFF
--- a/content/topics/i18n.md
+++ b/content/topics/i18n.md
@@ -1,11 +1,11 @@
 +++
-title = "Internationalisation"
+title = "Internationalization"
 
 [extra]
 
 level = 4
 
-intro = "Internationalisation is still a work in progress. There is no standard mature implementation of i18n in Rust, although there are many newer libraries aiming to fill this gap."
+intro = "Internationalization is still a work in progress. There is no standard mature implementation of i18n in Rust, although there are many newer libraries aiming to fill this gap."
 
 
 packages = [


### PR DESCRIPTION
The correct way to spell internationalization is with Z :)