### PR TITLE
Add frender to frameworks

### DIFF
--- a/content/topics/frameworks.md
+++ b/content/topics/frameworks.md
@@ -26,7 +26,8 @@ frontend = [
   "percy",
   "sauron",
   "seed",
-  "yew"
+  "yew",
+  "frender"
 ]
 
 newstag = "frameworks"


### PR DESCRIPTION
[frender](https://github.com/frender-rs/frender) is a framework for using react in rust with fully typed functional components.