### PR TITLE
Add Sycamore to list of frontend frameworks

### DIFF
--- a/content/topics/frameworks.md
+++ b/content/topics/frameworks.md
@@ -27,6 +27,7 @@ frontend = [
   "percy",
   "sauron",
   "seed",
+  "sycamore",
   "yew"
 ]
 


### PR DESCRIPTION
This PR adds [Sycamore](https://github.com/sycamore-rs/sycamore) to the list of frontend frameworks. I'm not sure if [Perseus](https://github.com/arctic-hen7/perseus) also belongs in the frontend section because it is more of a full stack solution than simply a frontend framework. I've left it out for now.