### PR TITLE
Remove `aspotify`

### DIFF
--- a/content/topics/web-apis.md
+++ b/content/topics/web-apis.md
@@ -9,7 +9,6 @@ level = 2
 
 packages = [
  "azure_sdk_for_rust",
- "aspotify",
  "rspotify",
  "twitter-api",
  "serenity",


### PR DESCRIPTION
This library has now been deprecated. See https://crates.io/crates/aspotify.