### PR TITLE
Add `web-lang` for matching languages

### DIFF
--- a/content/topics/i18n.md
+++ b/content/topics/i18n.md
@@ -14,7 +14,8 @@ packages = [
   "intl_pluralrules",
   "num-format",
   "rust_icu",
-  "unic"
+  "unic",
+  "web-lang"
 ]
 
 missing = [


### PR DESCRIPTION
I recently release a simple crate that provides language matching functionality based on Django.

The crate determines the best language match from a set of available languages, based on a specification of accepted languages (eg. the value of the `Accept-Language` header).

I added it to the list in the hope that it can be useful to others.