### PR TITLE
Remove iron, percy and mogwai from web frameworks

### DIFF
--- a/content/topics/frameworks.md
+++ b/content/topics/frameworks.md
@@ -10,7 +10,6 @@ intro = "When building a modern web-application you don't want to bother on how 
 server = [
   "actix-web",
   "gotham",
-  "iron",
   "nickel",
   "rocket",
   "tide",
@@ -24,8 +23,6 @@ server = [
 frontend = [
   "dioxus",
   "iced",
-  "mogwai",
-  "percy",
   "sauron",
   "seed",
   "sycamore",


### PR DESCRIPTION
Iron and Mogwai don't receive a commit since 2021, and percy has no documentation and no repo.