### PR TITLE
Add Perseus to framework list

### DIFF
--- a/content/topics/frameworks.md
+++ b/content/topics/frameworks.md
@@ -24,6 +24,7 @@ frontend = [
   "leptos",
   "dioxus",
   "iced",
+  "perseus",
   "sauron",
   "seed",
   "sycamore",


### PR DESCRIPTION
[Perseus](https://github.com/framesurge/perseus) is a state-based Rust/Wasm web development framework that builds on [Sycamore](https://github.com/sycamore-rs/sycamore) (already listed). It currently has ~1.2k stars on GitHub, and I think it would be helpful for new users of the Rust-Wasm ecosystem to be aware of it through this website!

*Disclaimer: I am the maintainer of Perseus.*