### PR TITLE
rbatis is a notable compile-time ORM

### DIFF
--- a/content/topics/database.md
+++ b/content/topics/database.md
@@ -13,7 +13,6 @@ drivers = [
   "mysql_async",
   "postgres",
   "redis",
-  "rbatis",
   "darkredis",
   "rusqlite",
   "tokio-postgres",
@@ -30,6 +29,7 @@ drivers = [
 
 orms = [
   "diesel",
+  "rbatis",
   "rustorm",
   "sea-orm",
   "tql"

--- a/templates/home.html
+++ b/templates/home.html
@@ -22,7 +22,10 @@
 
   <ul>
     <li>
-      <a href="/topics/database/#pkg-diesel">Diesel</a>, a full-fledged ORM.
+      <a href="/topics/database/#pkg-diesel">Diesel</a>, a full-fledged, type-safe ORM.
+    </li>
+    <li>
+      <a href="/topics/database/#pkg-rbatis">Rbatis</a>, a compile-time ORM.
     </li>
     <li>
       <a href="/topics/database/#pkg-sqlx">sqlx</a>, the async sql toolkit.


### PR DESCRIPTION
diesel.rs need client library needed for a database backend for type-safety among other things. While rbatis does not guaranteer type-safety, not requiring a client library makes it a compile time ORM and many time easier to work with.