### PR TITLE
Add Silkenweb frontend web framework

### DIFF
--- a/content/topics/frameworks.md
+++ b/content/topics/frameworks.md
@@ -26,6 +26,7 @@ frontend = [
   "iced",
   "sauron",
   "seed",
+  "silkenweb",
   "sycamore",
   "yew"
 ]


### PR DESCRIPTION
Notable differences to other Rust frameworks:

- Plain Rust: No macro DSL to learn.
- Currently the fastest high level Rust framework on <https://krausest.github.io/js-framework-benchmark/>