### PR TITLE
Promote Axum over Rocket

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -16,7 +16,7 @@
   
   <p>
     Rust has mature and production ready frameworks in <a href="/topics/frameworks/#pkg-actix-web">Actix Web</a> and
-    <a href="/topics/frameworks/#pkg-axum">Axum</a>, and newer ones like <a href="/topics/frameworks/#pkg-warp">Warp</a>
+    <a href="/topics/frameworks/#pkg-axum">Axum</a>, and innovative ones like <a href="/topics/frameworks/#pkg-warp">Warp</a>
     and <a href="/topics/frameworks/#pkg-tide">Tide</a>. These provide everything you’d expect from a web framework, from routing
     and middleware, to templating, and JSON/form handling. There are crates for everything, and more! For databases, there’s:</p>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -16,7 +16,7 @@
   
   <p>
     Rust has mature and production ready frameworks in <a href="/topics/frameworks/#pkg-actix-web">Actix Web</a> and
-    <a href="/topics/frameworks/#pkg-rocket">Rocket</a>, and newer ones like <a href="/topics/frameworks/#pkg-warp">Warp</a>
+    <a href="/topics/frameworks/#pkg-axum">Axum</a>, and newer ones like <a href="/topics/frameworks/#pkg-warp">Warp</a>
     and <a href="/topics/frameworks/#pkg-tide">Tide</a>. These provide everything you’d expect from a web framework, from routing
     and middleware, to templating, and JSON/form handling. There are crates for everything, and more! For databases, there’s:</p>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -100,7 +100,7 @@
         (Series)</a></li>
     <li><a href="https://dev.to/werner/practical-rust-web-development-api-rest-29g1">Practical Rust Web Development
         (Series)</a></li>
-    <li><a href="https://rocket.rs/v0.4/guide/quickstart/">Rocket Quickstart Guide</a></li>
+    <li><a href="https://rocket.rs/v0.5-rc/guide/quickstart/">Rocket Quickstart Guide</a></li>
   </ul>
 
   <p>There are also some real world examples that can be looked at for reference:</p>


### PR DESCRIPTION
closes #402

I only swapped out the frameworks in the first, most prominent paragraph and left the other Rocket related references as they are. I think Rocket is a great framework and pointers to Rocket related resources are valuable. But for newcomers to the ecosystem, it is currently not the best default recommendation.

I also updated the link to Rocket's quick start guide to the release candidate of the `0.5` version. The `0.4` branch requires nightly and migrating to `0.5` is a major paradigm shift, going to `async`. So I wouldn't recommend that to people starting with a greenfield project.