### PR TITLE
Remove oxidizer from database.md

### DIFF
--- a/content/topics/database.md
+++ b/content/topics/database.md
@@ -49,9 +49,7 @@ tools = [
   "refinery"
 ]
 
-upcoming = [
-  { name = "Oxidizer", url = "https://github.com/oxidizer-rs/oxidizer", desc = "A Rust ORM based on tokio-postgres and refinery" }
-]
+upcoming = []
 
 newstag = "database"
 +++


### PR DESCRIPTION
[Oxidizer is EOL](https://github.com/oxidizer-rs/oxidizer#%EF%B8%8F-important-%EF%B8%8F) and no longer will be worked on.

See more here: https://github.com/oxidizer-rs/oxidizer#readme.

I've left the upcoming section as `upcoming = []`. Not too sure if we'd want to persist that section if there's no entries for it though?