### PR TITLE
Add `imap-codec` to email topic.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ right procedure outlined below.
 ## Adding or Removing a package
 
 If a package isn't listed on the website yet, feel free to send us a pull-request for it. The only requirement 
-is that the pacakge is related to the web-stack, open source and is publicly available via [crates.io](http://www.crates.io).
+is that the package is related to the web-stack, open source and is publicly available via [crates.io](http://www.crates.io).
 Packages are separated into separate `topics`. Topics are located in the `context/topics` directory. Every topic contains 
-TOML frontmatter, from which the HTML is generated:
+a TOML frontmatter, from which the HTML is generated:
 
 ```
 +++
@@ -92,7 +92,7 @@ level = 0
 
 ## SubTopics
 
-Some topics do not have a `packages` array. These topics contain content after the frontmatter (after the second `+++`)
+Some topics do not have a `packages` array. These topics contain content after the frontmatter (after the second `+++`).
 Anything after the second `+++` is then rendered after the title in the top of the page, before the packages are listed.
 For example, the database topic is separated into `drivers`, and `orms`:
 ```

--- a/content/topics/email.md
+++ b/content/topics/email.md
@@ -15,7 +15,7 @@ packages = [
   "imap-proto",
   "lettre",
   "mailchimp",
-  "mrml"
+  "mrml",
   "samotop",
   "sendgrid",
 ]

--- a/content/topics/email.md
+++ b/content/topics/email.md
@@ -11,12 +11,13 @@ packages = [
   "async-imap",
   "email",
   "imap",
+  "imap-codec",
   "imap-proto",
   "lettre",
-  "sendgrid",
-  "samotop",
   "mailchimp",
   "mrml"
+  "samotop",
+  "sendgrid",
 ]
 
 newstag = "email"


### PR DESCRIPTION
`imap-codec` provides parsing, serialization, and support for [IMAP4rev1](https://tools.ietf.org/html/rfc3501). It's the most feature-complete IMAP parser/serializer that I'm aware of, and supports the client and server side. Furthermore, it is well-tested and exposes its functionality in a misuse-resistant way so that no invalid IMAP messages can be created.

While reading how to contribute, I also fixed a few typos. I wasn't sure at what position to add `imap-codec`. But it looked (almost) alphabetical, so I reordered and stuck to it. I could also put a sentence on ordering into CONTRIBUTING.md. Please tell me if there is another procedure.

(I'm the primary author of the library :-))