### PR TITLE
Remove `cargo-node` because its repository is not found

### DIFF
--- a/content/topics/nodejs.md
+++ b/content/topics/nodejs.md
@@ -8,7 +8,6 @@ level = 0
 intro = "Rust can be used to write fast and safe native Node.js modules through bindings to the V8 engine!"
 
 packages = [
-  "cargo-node",
   "napi",
   "neon",
   "node-bindgen",


### PR DESCRIPTION
Close https://github.com/rust-lang/arewewebyet/issues/416