### PR TITLE
Update syndication.md to fix typos

### DIFF
--- a/content/topics/syndication.md
+++ b/content/topics/syndication.md
@@ -5,7 +5,7 @@ title = "Syndication/RSS"
 
 level = 1
 
-intro = "Syndication has often be announced dead just to still stick around. Parse and generating good RSS feeds isn't especially hard, but also something you don't necessarily want to have to do yourself. There are some libraries and packages to help you with that."
+intro = "Syndication has often been announced dead just to still stick around. Parsing and generating good RSS feeds isn't especially hard, but also something you don't necessarily want to have to do yourself. There are some libraries and packages to help you with that."
 
 packages = [
   "atom_syndication",


### PR DESCRIPTION
This fixes two typos or word-choice problems describing what syndication packages are for.