### PR TITLE
Add the `wtx` project

### DIFF
--- a/content/topics/binary-protocols.md
+++ b/content/topics/binary-protocols.md
@@ -16,7 +16,8 @@ packages = [
   "tarpc",
   "tonic",
   "flatbuffers",
-  "thrift"
+  "thrift",
+  "wtx"
 ]
 
 

--- a/content/topics/database.md
+++ b/content/topics/database.md
@@ -22,7 +22,8 @@ drivers = [
   "cassandra-cpp",
   "memcache",
   "mongodb",
-  "sqlx"
+  "sqlx",
+  "wtx"
 ]
 
 orms = [

--- a/content/topics/frameworks.md
+++ b/content/topics/frameworks.md
@@ -15,7 +15,8 @@ server = [
   "warp",
   "axum",
   "poem",
-  "salvo"
+  "salvo",
+  "wtx"
 ]
 
 frontend = [

--- a/content/topics/lower-web-stack.md
+++ b/content/topics/lower-web-stack.md
@@ -11,13 +11,15 @@ http = [
   "async-h1",
   "h2",
   "hyper",
-  "tiny-http"
+  "tiny-http",
+  "wtx"
 ]
 
 websocket = [
   "tungstenite",
   "async-tungstenite",
-  "tokio-tungstenite"
+  "tokio-tungstenite",
+  "wtx"
 ]
 
 protocols = [


### PR DESCRIPTION
For some reason `wtx` was removed... Let me explain the project again.

[wtx](https://github.com/c410-f3r/wtx) is, among other things, a [RFC6455](https://datatracker.ietf.org/doc/html/rfc6455), [RFC7541](https://datatracker.ietf.org/doc/html/rfc7541), [RFC7692](https://datatracker.ietf.org/doc/html/rfc7692) and [RFC9113](https://datatracker.ietf.org/doc/html/rfc9113) implementation intended to allow the development of web applications through a built-in server framework, a built-in `PostgreSQL` connector, a built-in `WebSocket` handler and a built-in `gRPC` manager. There is also a built-in API client framework that facilitates the maintainability of large endpoints.

Here goes a list of related benchmarks:

* https://c410-f3r.github.io/wtx-bench/
* https://github.com/diesel-rs/metrics
* https://i.imgur.com/Iv2WzJV.jpg
* https://github.com/LesnyRumcajs/grpc_bench/pull/473
* https://i.imgur.com/vf2tYxY.jpg

