### PR TITLE
macros/package: Use `?include=` for crates.io requests

### DIFF
--- a/templates/macros/package.html
+++ b/templates/macros/package.html
@@ -1,5 +1,5 @@
 {% macro package(pkg_name) %}
-{% set pkg = load_data(url="https://crates.io/api/v1/crates/" ~ pkg_name, format="json") %}
+{% set pkg = load_data(url="https://crates.io/api/v1/crates/" ~ pkg_name ~ "?include=", format="json") %}
 {% if pkg %}
   {% set pkg = pkg.crate %}
 <li id="pkg-{{pkg.id | default(value=pkg.name)}}" class="pkg">


### PR DESCRIPTION
By default that crates.io endpoint is including a bunch of related information that we don't actually need for this template. This extra information is slowing down the responses since additional database queries are required. With this commit the server regularly responds in 1-2ms while previously it was 5-10ms. This brought down the build time from 100s to 35s for me.

r? @rust-lang/arewewebyet 