### PR TITLE
Make `CURRENT_TIME` env var optional

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -63,7 +63,12 @@
       </div>
     </div>
     <p class="last-updated">
-      Last updated {{ get_env(name="CURRENT_TIME") }} - <a href="https://github.com/rust-net-web/arewewebyet/#license">CC-BY-4.0</a>
+      {% set build_time = get_env(name="CURRENT_TIME", default=false) %}
+      {% if build_time %}
+        Last updated {{ build_time }} -
+      {% endif %}
+
+      <a href="https://github.com/rust-net-web/arewewebyet/#license">CC-BY-4.0</a>
     </p>
   </footer>
 </body>


### PR DESCRIPTION
When following the build instructions in the contribution guide `zola serve` was failing for me due to `CURRENT_TIME` not being defined. For local development this value isn't particularly critical so this commit makes it optional.

r? @rust-lang/arewewebyet 