### PR TITLE
Update curators page

### DIFF
--- a/authors.toml
+++ b/authors.toml
@@ -1,11 +1,10 @@
 [ben]
   name = "Benjamin Kampmann"
   curator = true
-  img = "http://www.create-build-execute.com/assets/images/ben.png"
+  img = "http://gnunicorn.org/assets/images/ben.png"
   bio = "Freelance OpenSource Software Architect and Developer. I design, build and supervise the building of software (systems). Sometimes for clients, often times on my own, whenever possible as OpenSource. I care about good design in both, the User Experience and backend architecture and infrastructure. And I write about all this stuff."
-  twitter = "SirDonQui"
-  github = "ligthyear"
-  homepage = "http://www.create-build-execute.com"
+  github = "gnunicorn"
+  homepage = "http://gnunicorn.org/"
 
 [manishearth]
   name = "Manish Goregaokar"

--- a/authors.toml
+++ b/authors.toml
@@ -1,3 +1,13 @@
+[giraffate]
+  name = "Takayuki Nakata"
+  curator = true
+  github = "giraffate"
+
+[ibraheemdev]
+  name = "Ibraheem Ahmed"
+  curator = true
+  github = "ibraheemdev"
+
 [ben]
   name = "Benjamin Kampmann"
   curator = true

--- a/authors.toml
+++ b/authors.toml
@@ -10,7 +10,6 @@
 
 [ben]
   name = "Benjamin Kampmann"
-  curator = true
   img = "http://gnunicorn.org/assets/images/ben.png"
   bio = "Freelance OpenSource Software Architect and Developer. I design, build and supervise the building of software (systems). Sometimes for clients, often times on my own, whenever possible as OpenSource. I care about good design in both, the User Experience and backend architecture and infrastructure. And I write about all this stuff."
   github = "gnunicorn"
@@ -18,7 +17,6 @@
 
 [manishearth]
   name = "Manish Goregaokar"
-  curator = "true"
   img = "https://www.gravatar.com/avatar/0a3069491bfded90cdf623341cadc1d1?s=512&amp;d=identicon&amp;r=PG"
   bio = "I’m a fourth year physics student studying at IIT Bombay. In my spare time I do a lot of programming, often open source, and participate in communities like Stack Exchange. These days I contribute to the [Servo browser engine](http://github.com/servo/servo) and occasionally to the [Rust programming language](http://github.com/rust-lang/rust)"
   twitter = "Manishearth"

--- a/sass/styles/authors.scss
+++ b/sass/styles/authors.scss
@@ -17,40 +17,39 @@
 }
 
 .avatar {
-  height: 10em;
-  margin: 0.5em;
+  grid-area: avatar;
+  height: 3em;
+  margin-right: 1em;
   border-radius: 50%;
   border: 2px #eee solid;
-  float: left;
+  align-self: center;
 }
 
 .author {
   margin: 2em 0;
-}
-
-.author:not(:last-child):after {
-  content: " ";
-  border-bottom: 2px #eee solid;
-  width: 50%;
-}
-
-.author:nth-child(2n) .avatar {
-  float: right;
+  display: grid;
+  grid-template:
+    "avatar name" auto
+    "avatar social" auto
+    "bio bio" auto
+    / auto 1fr;
 }
 
 .social-media {
-  margin: 0 0 1em 0;
+  grid-area: social;
+  margin: 0;
 }
 
 .social-media a {
-  margin: .45rem 2rem 0 0;
+  margin-left: .7em;
   display: inline-block;
-
-  @include for-tablet-portrait-up {
-    margin: .25rem 1rem 0 0;
-  }
 }
 
 .social-media a:first-of-type {
   margin-left: 0;
+}
+
+.bio {
+  grid-area: bio;
+  margin: .5em 0 1em;
 }

--- a/templates/macros/author.html
+++ b/templates/macros/author.html
@@ -2,6 +2,8 @@
 <div class="author" id="{{key}}">
   {% if author.img %}
     <img class="avatar" src="{{author.img}}" />
+  {% elif author.github %}
+    <img class="avatar" src="https://www.github.com/{{author.github}}.png" />
   {% else %}
     <img class="avatar" src="{{get_url(path='/asset/bashy-big.svg')}}" />
   {% endif %}

--- a/templates/macros/author.html
+++ b/templates/macros/author.html
@@ -1,6 +1,10 @@
 {% macro author(key, author) %}
 <div class="author" id="{{key}}">
-  <img class="avatar" src="{{author.img | default(value=get_url(path='/asset/bashy-big.svg'))}}" />
+  {% if author.img %}
+    <img class="avatar" src="{{author.img}}" />
+  {% else %}
+    <img class="avatar" src="{{get_url(path='/asset/bashy-big.svg')}}" />
+  {% endif %}
   {% if author.curator %}
   <a href="/curators/#{{key}}">
     {% endif %}


### PR DESCRIPTION
This PR updates https://www.arewewebyet.org/curators/ to match the current team of maintainers (see https://github.com/rust-lang/team/blob/master/teams/arewewebyet.toml)

It also adjusts the styling of that page to make it look better when authors only have minimal information:

![Bildschirmfoto 2024-02-28 um 10 36 24](https://github.com/rust-lang/arewewebyet/assets/141300/e0983d5d-71f8-46f5-8dc3-740c146a0f45)

r? @rust-lang/arewewebyet 