### PR TITLE
Fixed broken Rocket Quickstart link

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -100,7 +100,7 @@
         (Series)</a></li>
     <li><a href="https://dev.to/werner/practical-rust-web-development-api-rest-29g1">Practical Rust Web Development
         (Series)</a></li>
-    <li><a href="https://rocket.rs/v0.5-rc/guide/quickstart/">Rocket Quickstart Guide</a></li>
+    <li><a href="https://rocket.rs/guide/v0.5/quickstart/">Rocket Quickstart Guide</a></li>
   </ul>
 
   <p>There are also some real world examples that can be looked at for reference:</p>


### PR DESCRIPTION
Rocket's QuickStart guide's link was broken (Error 404). The guide itself still exists; the link just changed because the v0.5's Release Candidate just became the final v0.5 Release.