### PR TITLE
Fix broken config file

### DIFF
--- a/.github/workflows/zola.yml
+++ b/.github/workflows/zola.yml
@@ -9,18 +9,18 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Zola
         run: | 
-          wget "https://github.com/getzola/zola/releases/download/v0.12.2/zola-v0.12.2-x86_64-unknown-linux-gnu.tar.gz"
-          sudo tar xzf ./zola-v0.12.2-x86_64-unknown-linux-gnu.tar.gz
+          wget "https://github.com/getzola/zola/releases/download/v0.19.1/zola-v0.19.1-x86_64-unknown-linux-gnu.tar.gz"
+          sudo tar xzf ./zola-v0.19.1-x86_64-unknown-linux-gnu.tar.gz
 
       - name: Build
         run: "export CURRENT_TIME=$(date '+%d %B %Y'); ./zola build"
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/config.toml
+++ b/config.toml
@@ -4,12 +4,13 @@ base_url = "https://www.arewewebyet.org/"
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
 
+# Whether to build a search index to be used later on by a JavaScript library
+build_search_index = false
+
+[markdown]
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = false
-
-# Whether to build a search index to be used later on by a JavaScript library
-build_search_index = false
 
 [extra]
 # Put all your custom variables here


### PR DESCRIPTION
When trying to run the site locally with `zola serve` we have the following error:

```bash
> zola -V
zola 0.19.1

> zola serve
Error: Failed to serve the site
Error: TOML parse error at line 9, column 1
  |
9 | highlight_code = false
  | ^^^^^^^^^^^^^^
unknown field `highlight_code`, expected one of `base_url`, `theme`, `title`, `description`, `default_language`, `languages`, `translations`, `generate_feeds`, `feed_limit`, `feed_filenames`, `hard_link_static`, `taxonomies`, `author`, `compile_sass`, `minify_html`, `build_search_index`, `ignored_content`, `ignored_static`, `mode`, `output_dir`, `preserve_dotfiles_in_output`, `link_checker`, `slugify`, `search`, `markdown`, `extra`
```

This PR fixes this problem by moving the `highlight_code` key under the `[markdown]` section in  `config.toml` as seen in the [zola configuration doc](https://www.getzola.org/documentation/getting-started/configuration/).