### PR TITLE
Remove seed-rs from webassembly section

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -78,8 +78,8 @@
   <p>Rust can run on the browser by compiling to <a href="/topics/webassembly/">WebAssembly</a>
     {{ level::level(level=webassembly.extra.level) }}. This means that you can take advantage of the amazing Rust ecosystem on the browser! Rust and
     WebAssembly integrate with existing Javascript tooling like NPM, Webpack, and ECMAScript modules! There are
-    some <a href="/topics/webassembly/">awesome Rust and WebAssembly</a> projects out there. For example, <a
-      href="https://github.com/yewstack/yew">Yew</a> and <a href="https://github.com/seed-rs/seed">Seed</a> let you create
+    some <a href="/topics/webassembly/">awesome Rust and WebAssembly</a> projects out there. For example <a
+      href="https://github.com/yewstack/yew">Yew</a> lets you create
     front-end web apps with Rust in a way that feels almost like React.js.</p>
 
   <p>For more information about Rust and WebAssembly, check out the <a


### PR DESCRIPTION
The seed-rs README file at https://github.com/seed-rs/seed links to seed-rs.org which redirects to formatshop.it, which is _not_ a seed-rs resource.

From that (the projects website being that) I conclude that the project is dead.

---

I am not sure what your policy here is, but since the project website redirects to some (actually a bit scammy looking) website, removing the project at least from the more prominent parts of the AWWY website seems like a good step to me.