### PR TITLE
Add a script to check for various inclusion criterias

### DIFF
--- a/content/topics/asyncio.md
+++ b/content/topics/asyncio.md
@@ -12,6 +12,7 @@ packages = [
   "async-std",
   "async-stream",
   "async-trait",
+  "bastion",
   "futures",
   "futures-intrusive",
   "futures-timer",

--- a/content/topics/auth.md
+++ b/content/topics/auth.md
@@ -13,6 +13,7 @@ packages = [
   "jsonwebtoken",
   "oauth2",
   "openssl",
+  "otpauth",
   "oxide-auth",
   "yup-oauth2"
 ]

--- a/content/topics/crypto.md
+++ b/content/topics/crypto.md
@@ -10,7 +10,6 @@ intro = "Cryptography is a corner stone of a trusted web. Without it many servic
 suites = [
   "openssl",
   "orion",
-  "libsodium-sys",
   "gpgme",
   "ring"
 ]

--- a/content/topics/email.md
+++ b/content/topics/email.md
@@ -11,6 +11,7 @@ packages = [
   "async-imap",
   "email",
   "imap",
+  "imap-codec",
   "imap-proto",
   "lettre",
   "mail-auth",

--- a/content/topics/frameworks.md
+++ b/content/topics/frameworks.md
@@ -12,6 +12,7 @@ server = [
   "gotham",
   "rocket", 
   "tide",
+  "thruster",
   "warp",
   "axum",
   "poem",

--- a/content/topics/lower-web-stack.md
+++ b/content/topics/lower-web-stack.md
@@ -17,7 +17,8 @@ http = [
 websocket = [
   "tungstenite",
   "async-tungstenite",
-  "tokio-tungstenite"
+  "tokio-tungstenite",
+  "wtx"
 ]
 
 protocols = [

--- a/content/topics/serializer.md
+++ b/content/topics/serializer.md
@@ -13,7 +13,6 @@ packages = [
   "rmp",
   "serde",
   "serde_json",
-  "serde_yaml",
   "serde_bytes",
   "toml",
   "quick-xml"

--- a/content/topics/syndication.md
+++ b/content/topics/syndication.md
@@ -10,6 +10,7 @@ intro = "Syndication has often been announced dead just to still stick around. P
 packages = [
   "atom_syndication",
   "rss",
+  "rrss2imap",
   "feed-rs"
 ]
 

--- a/content/topics/templating.md
+++ b/content/topics/templating.md
@@ -12,10 +12,15 @@ packages = [
   "askama",
   "tera",
   "handlebars",
+  "sailfish",
+  "horrorshow",  
   "liquid",
+  "yarte",
   "maud",
   "markup",
   "pulldown-cmark",
+  "ramhorns",
+  "ructe",
   "comrak",
   "minijinja"
 ]

--- a/content/topics/wasm-runtimes.md
+++ b/content/topics/wasm-runtimes.md
@@ -9,8 +9,7 @@ intro = "While the main showcase of WebAssembly initially was the web browser, t
 
 packages = [
   "wasmer",
-  "wasmtime",
-  "watt"
+  "wasmtime"
 ]
 
 newstag = "webassembly-runtimes"

--- a/content/topics/webassembly.md
+++ b/content/topics/webassembly.md
@@ -14,7 +14,6 @@ packages=  [
   "dominator",
   "futures-signals",
   "gloo",
-  "parity-wasm",
   "plotters",
   "stdweb",
   "wasm-bindgen",

--- a/scripts/check_criterias.sh
+++ b/scripts/check_criterias.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+#
+# Usage: ./scripts/check_criterias.sh "<GITHUB_TOKEN>" "<GITLAB_TOKEN>"
+#
+# - Generate a Github personal access token on https://github.com/settings/tokens
+# - Generate a Gitlab personal access token on https://gitlab.com/-/user_settings/personal_access_tokens
+GITHUB_TOKEN="$1"
+GITLAB_TOKEN="$2"
+
+CRATE_REGEX='^[[:space:]]{1,2}"([A-Za-z0-9_-]+)",?'
+EXCLUDE_CRATE="Facebook"
+SEARCH_DIR=content/topics
+DUPLICATES=()
+MIN_RECENT_DOWNLOADS=4000
+DEPRECATED_WORDS=("unmaintained" "deprecated" "discontinued" "no longer maintained")
+
+# Retrieve all crates present in the project
+for entry in "$SEARCH_DIR"/*.md
+do
+  while IFS= read -r line; do
+    if [[ "$line" =~ $CRATE_REGEX ]]; then
+      DUPLICATES+=("${BASH_REMATCH[1]}")
+    fi
+  done < "$entry"
+done
+
+# Remove duplicates
+CRATES=($(for crate in "${DUPLICATES[@]/$EXCLUDE_CRATE}"; do echo "${crate}"; done | sort -u))
+
+echo "Checking ${#CRATES[@]} crates:"
+
+for crate in "${CRATES[@]}"; do
+  echo "- $crate"
+
+  #
+  # The package must have at least 4k recent downloads on crates.io
+  DATA=$(curl -s -H "Accept:application/json" "https://crates.io/api/v1/crates/$crate")
+  RECENT_DOWNLOADS=$(jq -r '.crate.recent_downloads' <<< "$DATA")
+  REPOSITORY=$(jq -r '.crate.repository' <<< "$DATA")
+  REPOSITORY=${REPOSITORY%.git} # Remove .git suffix
+  REPOSITORY=${REPOSITORY%/} # Remove trailing slash
+  DESCRIPTION=$(jq -r '.crate.description' <<< "$DATA")
+
+  if [ "$RECENT_DOWNLOADS" -lt $MIN_RECENT_DOWNLOADS ]; then
+    echo "** crate has less than 4k recent downloads on crates.io"
+  fi
+
+  for word in "${DEPRECATED_WORDS[@]}"; do
+    lower=$(echo "$DESCRIPTION" | tr "[:upper:]" "[:lower:]")
+
+    if [[ "$lower" == *"$word"* ]]; then
+      echo "** crate may be deprecated or unmaintained"
+    fi
+  done
+
+  #
+  # The package's repository is not archived
+  OWNER_REPO="${REPOSITORY#https://github.com/}"
+  ENCODED_OWNER_REPO="${OWNER_REPO//\//%2F}"
+
+  if [[ "$REPOSITORY" == *"github.com"* ]]; then
+    DATA=$(curl -s -H "Accept:application/json" -H "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/$OWNER_REPO")
+    STATUS=$(jq -r '.status' <<< "$DATA")
+    if [ "$STATUS" != null ]; then
+      echo "** unable to retrieve api github data from ${REPOSITORY}"
+    fi
+
+    ARCHIVED=$(jq -r '.archived' <<< "$DATA")
+  elif [[ "$REPOSITORY" == *"bitbucket.org"* ]]; then
+    #DATA=$(curl -s -H "Accept:application/json" "https://api.bitbucket.org/2.0/repositories/$OWNER_REPO")
+    # No "archived" status on Bitbucket: https://jira.atlassian.com/browse/BCLOUD-18018
+    ARCHIVED="false"
+  elif [[ "$REPOSITORY" == *"gitlab.com"* ]]; then
+    DATA=$(curl -s -H "Accept:application/json" -H "Authorization: Bearer $GITLAB_TOKEN" "https://gitlab.com/api/v4/projects/$ENCODED_OWNER_REPO")
+    MESSAGE=$(jq -r '.message' <<< "$DATA")
+    if [ "$MESSAGE" != null ]; then
+      echo "** unable to retrieve api gitlab data from ${REPOSITORY}"
+    fi
+
+    ARCHIVED=$(jq -r '.archived' <<< "$DATA")
+  else
+    echo "** unknown repository type for: $REPOSITORY"
+  fi
+
+  if [ "$ARCHIVED" == "true" ]; then
+    echo "** repository is archived"
+  fi
+
+  # TODO
+  #
+  # The package is not flagged as unmaintained in https://rustsec.org/
+
+  sleep .5
+done


### PR DESCRIPTION
As promised [almost 3 months ago](https://github.com/rust-lang/arewewebyet/pull/437#issuecomment-2249868505), here's a script that checks for the following criterias for the existing crates listed on the repo:
- The crate has at least 4k recent downloads on crates.io
- The package's repository is not archived

I also added back crates I previously removed by error and cleaned existing ones that did not meet the above criterias.

Please note that I am by no means any good in bash scripting so I did my very best here and probably spent too much time writing those lines.

As a future addition in another PR, we can add the check to the last criteria (`"The package is not flagged as unmaintained in the Rust security advisory database"`) to clean some crates that have gone unmaintained for many years.