### PR TITLE
Update web-apis.md to switch nats to async-nats

### DIFF
--- a/content/topics/web-apis.md
+++ b/content/topics/web-apis.md
@@ -13,7 +13,7 @@ packages = [
  "google_maps",
  "google-drive",
  "teloxide",
- "nats",
+ "async-nats",
 ]
 
 missing = [


### PR DESCRIPTION
Hello!

This is a small change I've noticed while looking at website, basically nats crate is no longer maintained and recommends switching to async-nats in the README.