### PR TITLE
Add rusty_paseto to auth packages

### DIFF
--- a/content/topics/auth.md
+++ b/content/topics/auth.md
@@ -14,6 +14,7 @@ packages = [
   "oauth2",
   "openssl",
   "oxide-auth",
+  "rusty_paseto",
   "yup-oauth2"
 ]
 


### PR DESCRIPTION
## Summary
- Adds [rusty_paseto](https://crates.io/crates/rusty_paseto) to the authentication packages list

## Why rusty_paseto?

[PASETO](https://paseto.io) (Platform-Agnostic Security Tokens) is a secure alternative to JWT that addresses many of JWT's design flaws. rusty_paseto is a mature Rust implementation that:

- Supports all PASETO versions (v1-v4) for both local and public tokens
- Recently added PASERK support (v0.9.0)
- Has been **used in production by [Atuin](https://github.com/atuinsh/atuin)** (the popular shell history sync tool) for years
- Passes all official PASETO test vectors
- Is listed on the official [paseto.io implementations page](https://paseto.io)

This is a follow-up to PR #347 from 2022, which was closed with a suggestion to resubmit after the crate matured. The crate has since proven its stability through real-world production use.